### PR TITLE
Experimental fast setup

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -12,6 +12,7 @@ module Bundler
   preserve_gem_path
   ORIGINAL_ENV = ENV.to_hash
 
+  autoload :CachedRuntime,         "bundler/cached_runtime"
   autoload :Definition,            "bundler/definition"
   autoload :Dependency,            "bundler/dependency"
   autoload :DepProxy,              "bundler/dep_proxy"
@@ -108,6 +109,7 @@ module Bundler
 
   class << self
     attr_writer :bundle_path
+    attr_accessor :runtime_implementation
 
     def configure
       @configured ||= configure_gem_home_and_path
@@ -156,7 +158,7 @@ module Bundler
     end
 
     def load
-      @load ||= Runtime.new(root, definition)
+      @load ||= (runtime_implementation || Runtime).new(root, definition)
     end
 
     def environment

--- a/lib/bundler/cached_runtime.rb
+++ b/lib/bundler/cached_runtime.rb
@@ -14,8 +14,8 @@ module Bundler
       self
     end
 
-    def cache
-      @cache ||= RequireCache.new(@load_paths)
+    def require_cache
+      @require_cache ||= RequireCache.new(@load_paths)
     end
 
     private
@@ -23,7 +23,7 @@ module Bundler
         super if self.class.blacklist.include?(spec.name)
         @load_paths ||= []
         @load_paths += spec.load_paths
-        @cache = nil
+        @require_cache = nil
       end
   end
 end

--- a/lib/bundler/cached_runtime.rb
+++ b/lib/bundler/cached_runtime.rb
@@ -1,0 +1,29 @@
+require 'bundler/runtime'
+require 'bundler/require_cache'
+
+module Bundler
+  class CachedRuntime < Runtime
+    class << self
+      attr_accessor :blacklist
+    end
+    self.blacklist = []
+
+    def setup(*)
+      super
+      require_relative 'require_patch'
+      self
+    end
+
+    def cache
+      @cache ||= RequireCache.new(@load_paths)
+    end
+
+    private
+      def register_load_paths(spec)
+        super if self.class.blacklist.include?(spec.name)
+        @load_paths ||= []
+        @load_paths += spec.load_paths
+        @cache = nil
+      end
+  end
+end

--- a/lib/bundler/require_cache.rb
+++ b/lib/bundler/require_cache.rb
@@ -1,0 +1,120 @@
+require 'set'
+require 'digest/md5'
+require 'tmpdir'
+require 'pathname'
+require 'bundler'
+require 'pp'
+
+module Bundler
+  class RequireCache
+    CACHE_VERSION = '1'
+    LEADING_SLASH = /^\//
+
+    DL_EXTENSIONS = [
+      RbConfig::CONFIG['DLEXT'],
+      RbConfig::CONFIG['DLEXT2'],
+    ].reject(&:empty?).map { |ext| ".#{ext}"}
+
+    NORMALIZED_SYSTEM_EXTENSION = '.so'.freeze
+    RUBY_EXTENSION = '.rb'.freeze
+    SYSTEM_EXTENSIONS = /#{Regexp.union(DL_EXTENSIONS)}\z/
+    QUALIFIED_NAME = /\.(rb|so|o|bundle|dylib)\z/
+
+    attr_reader :load_paths
+
+    def initialize(load_paths)
+      @load_paths = (load_paths + $LOAD_PATH).uniq
+      @initial_load_path = $LOAD_PATH.to_set
+      load_cache || build_and_dump
+    end
+
+    def [](path)
+      lookup_load_path(path) || lookup_cache(path)
+    end
+
+    private
+
+      def lookup_load_path(path)
+        possible_names = compute_possible_names(path, [RUBY_EXTENSION, *DL_EXTENSIONS])
+
+        dynamic_load_path.each do |load_path|
+          possible_names.each do |name|
+            absolute_path = File.join(load_path, name)
+            return absolute_path if File.exists?(absolute_path)
+          end
+        end
+        nil
+      end
+
+      def lookup_cache(path)
+        possible_names = compute_possible_names(path, [RUBY_EXTENSION, NORMALIZED_SYSTEM_EXTENSION])
+        possible_names.each do |name|
+          absolute_path = @cache[name]
+          return absolute_path if absolute_path
+        end
+        nil
+      end
+
+      def compute_possible_names(path, possible_extensions)
+        path = normalize_system_extension_path(path.to_s)
+        return [path] if path =~ QUALIFIED_NAME
+        possible_extensions.map { |ext| "#{path}#{ext}" }
+      end
+
+      def dynamic_load_path
+        $LOAD_PATH.reject { |path| @initial_load_path.include?(path) }
+      end
+
+      def build_and_dump
+        @cache = build
+        dump
+      end
+
+      def dump
+        File.open(cache_path.to_s, 'wb+') { |f| f.write(Marshal.dump(@cache)) }
+      end
+
+      def load_cache
+        return unless cache_path.exist?
+        @cache = Marshal.load(cache_path.read)
+      end
+
+      def build
+        cache = {}
+        each_file_in_load_paths(RUBY_EXTENSION) do |relative_path, absolute_path|
+          cache[relative_path] ||= absolute_path
+        end
+        each_file_in_load_paths(*DL_EXTENSIONS) do |relative_path, absolute_path|
+          cache[normalize_system_extension_path(relative_path)] ||= absolute_path
+        end
+        cache
+      end
+
+      def each_file_in_load_paths(*extensions, &block)
+        pattern = "**/*{#{extensions.join(',')}}"
+        load_paths.each do |load_path|
+          Dir["#{load_path}/#{pattern}"].each do |absolute_path|
+            relative_path = relativise_path(absolute_path, load_path)
+            yield relative_path, absolute_path
+          end
+        end
+      end
+
+      def relativise_path(path, directory)
+        path = path.sub(directory, '')
+        path.sub!(LEADING_SLASH, '')
+      end
+
+      def normalize_system_extension_path(path)
+        path.sub(SYSTEM_EXTENSIONS, NORMALIZED_SYSTEM_EXTENSION)
+      end
+
+      def cache_path
+        @cache_path ||= Pathname.new(Dir::tmpdir).join("bundler-cache-#{CACHE_VERSION}-#{cache_key}.marshal")
+      end
+
+      def cache_key
+        Digest::MD5.hexdigest(load_paths.join(':'))
+      end
+  end
+end

--- a/lib/bundler/require_cache.rb
+++ b/lib/bundler/require_cache.rb
@@ -3,7 +3,6 @@ require 'digest/md5'
 require 'tmpdir'
 require 'pathname'
 require 'bundler'
-require 'pp'
 
 module Bundler
   class RequireCache

--- a/lib/bundler/require_patch.rb
+++ b/lib/bundler/require_patch.rb
@@ -1,0 +1,33 @@
+class Module
+  def autoload_with_cache(const, path)
+    autoload_without_cache(const, Bundler.load.cache[path] || path)
+  end
+
+  alias_method :autoload_without_cache, :autoload
+  alias_method :autoload, :autoload_with_cache
+end
+
+class << Kernel
+  def require_with_cache(path)
+    require_without_cache(Bundler.load.cache[path] || path)
+  end
+
+  alias_method :require_without_cache, :require
+  alias_method :require, :require_with_cache
+end
+
+module Kernel
+  def require_with_cache(path)
+    require_without_cache(Bundler.load.cache[path] || path)
+  end
+
+  alias_method :require_without_cache, :require
+  alias_method :require, :require_with_cache
+
+  def autoload_with_cache(const, path)
+    autoload_without_cache(const, Bundler.load.cache[path] || path)
+  end
+
+  alias_method :autoload_without_cache, :autoload
+  alias_method :autoload, :autoload_with_cache
+end

--- a/lib/bundler/require_patch.rb
+++ b/lib/bundler/require_patch.rb
@@ -1,6 +1,6 @@
 class Module
   def autoload_with_cache(const, path)
-    autoload_without_cache(const, Bundler.load.cache[path] || path)
+    autoload_without_cache(const, Bundler.load.require_cache[path] || path)
   end
 
   alias_method :autoload_without_cache, :autoload
@@ -9,7 +9,7 @@ end
 
 class << Kernel
   def require_with_cache(path)
-    require_without_cache(Bundler.load.cache[path] || path)
+    require_without_cache(Bundler.load.require_cache[path] || path)
   end
 
   alias_method :require_without_cache, :require
@@ -18,14 +18,14 @@ end
 
 module Kernel
   def require_with_cache(path)
-    require_without_cache(Bundler.load.cache[path] || path)
+    require_without_cache(Bundler.load.require_cache[path] || path)
   end
 
   alias_method :require_without_cache, :require
   alias_method :require, :require_with_cache
 
   def autoload_with_cache(const, path)
-    autoload_without_cache(const, Bundler.load.cache[path] || path)
+    autoload_without_cache(const, Bundler.load.require_cache[path] || path)
   end
 
   alias_method :autoload_without_cache, :autoload

--- a/lib/bundler/require_patch.rb
+++ b/lib/bundler/require_patch.rb
@@ -25,7 +25,8 @@ module Kernel
   alias_method :require, :require_with_cache
 
   def autoload_with_cache(const, path)
-    autoload_without_cache(const, Bundler.load.require_cache[path] || path)
+    STDERR.puts "WARNING: Top level autoload is not properly supported yet, #{const} was eager loaded"
+    require(path)
   end
 
   alias_method :autoload_without_cache, :autoload

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -223,12 +223,12 @@ module Bundler
         end
 
         Bundler.rubygems.mark_loaded(spec)
-        register_load_paths(spec.load_paths)
+        register_load_paths(spec)
       end
     end
 
-    def register_load_paths(load_paths)
-      $LOAD_PATH.unshift(*load_paths.reject {|path| $LOAD_PATH.include?(path) })
+    def register_load_paths(spec)
+      $LOAD_PATH.unshift(*spec.load_paths.reject {|path| $LOAD_PATH.include?(path) })
     end
 
     def prune_gem_cache(resolve, cache_path)


### PR DESCRIPTION
### Problem

To make gems accessible, Bundler populate the `$LOAD_PATH`, then when `require` is called, the VM try to locate the
required file in all the `$LOAD_PATH` entries one by one. Long story short Ruby's require is `O(n)`, `n` being the `$LOAD_PATH.size`.
### Acknowledgements
- The list of files that can be required in single gem is unlikely to change at runtime.
- Therefore the list of files that can be required in the sum of all the gems is simply function of the `$LOAD_PATH` and can be cached.
- `require` is basically `O(1)` when provided with an absolute path
### Solution

This patch, during bundler setup, compute the list of all the files that can be required, and store it in a `Hash[relative_path => absolute_path]`

The cache is serialized in a file, with the all the gems `load_paths` as a cache key. If a single gem is added / removed / updated, the cache key change.

Then `require` is monkey patched to absolutize paths, using the cache.

Finally, bundler don't add the gems to the `$LOAD_PATH`, so that the `require` for code not loaded by bundler is not slowed down.
### Drawbacks

Some c extensions gems call the native `rb_require` or `rb_autoload` directly, therefore, the files they require must be kept in the `$LOAD_PATH`.
Gems can be blacklisted as follow `Bundler::CachedRuntime.blacklist += %w(snappy oj stackprof)`.

Unfortunately, this issue prevent this cached strategy from being the default one, that is why this patch is purely opt-in.
### Bugs

I haven't quite figured it out why yet, but `autoload` when called from the main object, doesn't behave properly.
I made it call require directly instead. That just "works" for now.
### Benchmark

Benchmark can be found here: https://github.com/byroot/fast-bundler-demo 

For a plain new Rails app with 53 gems, the improvement is barely 4%:

``` sh
$ bundle install
Bundle complete! 11 Gemfile dependencies, 53 gems now installed

$ ./script/benchmark
== Booting without cache:
RequireCache disabled
$LOAD_PATH.size => 77
        1.73 real         1.47 user         0.24 sys

== Warming cache (unless already present):
RequireCache enabled
$LOAD_PATH.size => 26
        1.67 real         1.47 user         0.18 sys

== Fast boot:
RequireCache enabled
$LOAD_PATH.size => 26
        1.67 real         1.47 user         0.19 sys
```

But for a sligthly bigger app with 136 gems, the app boot 20% faster.

``` sh
$ bundle install
Bundle complete! 65 Gemfile dependencies, 136 gems now installed.

$ ./script/benchmark
== Booting without cache:
RequireCache disabled
$LOAD_PATH.size => 184
        3.29 real         2.59 user         0.69 sys

== Warming cache (unless already present):
RequireCache enabled
$LOAD_PATH.size => 39
        2.74 real         2.44 user         0.29 sys

== Fast boot:
RequireCache enabled
$LOAD_PATH.size => 39
        2.62 real         2.33 user         0.27 sys
```

I tested it with a real world app with 324 gems and lots of initializers, the saving is around 25%.

``` sh
RequireCache disabled
$LOAD_PATH.size => 439
     14.14 real        10.85 user         3.19 sys

RequireCache enabled
$LOAD_PATH.size => 95
     10.79 real         9.52 user         1.18 sys
```

NB: I don't think it's quite ready for an upstream PR, but I'd love some bundler / MRI input at this point.

@tenderlove @andremedeiros thoughts on this?
